### PR TITLE
Fixed display of time in booking show

### DIFF
--- a/app/javascript/plugins/flatpickr.js
+++ b/app/javascript/plugins/flatpickr.js
@@ -7,7 +7,7 @@ const initFlatpickr = () => {
     time_24hr: true,
     altInput: true,
     altFormat: "F j, Y H:i",
-    dateFormat: "Y-m-d",
+    dateFormat: "Y-m-d H:i",
   });
 };
 

--- a/app/views/shared/_booking_card.html.erb
+++ b/app/views/shared/_booking_card.html.erb
@@ -12,7 +12,7 @@
       <p><i class="fa fa-calendar"></i>
         <%= booking.date.strftime("%a %d %b") %>
         <i class="fa fa-clock-o "></i>
-        <%= booking.date.strftime("%I:%M%p") %>
+        <%= booking.date.strftime("%H:%M") %>
       </p>
       <p><i class="fa fa-wrench"></i> 
         [<%= booking.item_type.name %>] 


### PR DESCRIPTION
The time in the booking show is being correctly displayed now in 24h format.